### PR TITLE
Fix env message typos

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -21,12 +21,12 @@ func initClientAndAPIContext(tb *testing.T) {
 
 	clientID, exists := os.LookupEnv("SHIPPINGLABEL_CLIENT_ID")
 	if !exists {
-		tb.Fatalf("could not found env: 'SHIPPINGLABEL_CLIENT_ID'")
+		tb.Fatalf("could not find env: 'SHIPPINGLABEL_CLIENT_ID'")
 	}
 
 	secret, exists := os.LookupEnv("SHIPPINGLABEL_CLIENT_SECRET")
 	if !exists {
-		tb.Fatalf("could not found env: 'SHIPPINGLABEL_CLIENT_SECRET'")
+		tb.Fatalf("could not find env: 'SHIPPINGLABEL_CLIENT_SECRET'")
 	}
 	var err error
 	client, err = NewClient(clientID, secret)


### PR DESCRIPTION
## Summary
- fix the typo in `initClientAndAPIContext`

## Testing
- `go test ./...` *(fails: could not find required env variables)*

------
https://chatgpt.com/codex/tasks/task_b_6846b4443e6c8324ad4177892cbd8f9d